### PR TITLE
Modernisierung: Kotlin 2.x, ViewModel, DataStore, vollständige String-Ressourcen

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,13 +33,14 @@ jobs:
       run: ./gradlew assemble
     - name: Sign APK
       uses: r0adkll/sign-android-release@v1
+      env:
+        BUILD_TOOLS_VERSION: 35.0.0
       with:
         releaseDirectory: app/build/outputs/apk/release
         signingKeyBase64: ${{ secrets.SIGNINGKEYBASE64 }} # openssl base64 < kleini-keystore.jks | tr -d '\n' | tee kleini-keystore.jks.base64.txt
         alias: ${{ secrets.ALIAS }}
         keyStorePassword: ${{ secrets.KEYSTOREPASSWORD }}
         keyPassword: ${{ secrets.KEYPASSWORD }}
-        buildToolsVersion: 35.0.0
     - name: Setup git
       run: |
         git config --global user.name ${{ secrets.ACTIONS_USERNAME }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,10 +22,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        java-version: 17
+        distribution: temurin
     - name: Make gradlew executable
       run: chmod +x ./gradlew
     - name: Build with Gradle

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -39,6 +39,7 @@ jobs:
         alias: ${{ secrets.ALIAS }}
         keyStorePassword: ${{ secrets.KEYSTOREPASSWORD }}
         keyPassword: ${{ secrets.KEYPASSWORD }}
+        buildToolsVersion: 35.0.0
     - name: Setup git
       run: |
         git config --global user.name ${{ secrets.ACTIONS_USERNAME }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,14 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.1"
+    namespace "de.kleini.lock"
+    compileSdk 35
 
     defaultConfig {
         applicationId "de.kleini.lock"
-        minSdkVersion 28
-        targetSdkVersion 30
+        minSdk 28
+        targetSdk 35
         versionCode 1
         versionName "1.5"
 
@@ -26,16 +25,26 @@ android {
             signingConfig null
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.1'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7'
+    implementation 'androidx.activity:activity-ktx:1.9.3'
+    implementation 'androidx.datastore:datastore-preferences:1.1.1'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,12 @@ android {
     kotlinOptions {
         jvmTarget = '17'
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -45,6 +51,10 @@ dependencies {
     implementation 'androidx.activity:activity-ktx:1.9.3'
     implementation 'androidx.datastore:datastore-preferences:1.1.1'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.13'
+    testImplementation 'androidx.test:core:1.6.1'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0'
+    testImplementation 'androidx.arch.core:core-testing:2.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/src/androidTest/java/de/kleini/lock/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/de/kleini/lock/ExampleInstrumentedTest.kt
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("de.kleini.pinlock", appContext.packageName)
+        assertEquals("de.kleini.lock", appContext.packageName)
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="de.kleini.lock">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
@@ -11,7 +10,10 @@
         android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/AppTheme.Translucent" >
-        <activity android:name=".App" android:configChanges="orientation|screenSize|keyboardHidden">
+        <activity
+            android:name=".App"
+            android:exported="true"
+            android:configChanges="orientation|screenSize|keyboardHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/de/kleini/lock/App.kt
+++ b/app/src/main/java/de/kleini/lock/App.kt
@@ -1,19 +1,17 @@
 package de.kleini.lock
 
-import android.content.SharedPreferences
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
 import android.view.View
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 
 
-class App() : AppCompatActivity() {
+class App : AppCompatActivity() {
 
-    private val TAG = "Activity"
-    lateinit var sharedPref: SharedPreferences
-    private var PRIVATE_MODE = 0
-    private val PREF_NAME = "store"
+    private val TAG = "App"
+    private val viewModel: LockViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -21,11 +19,10 @@ class App() : AppCompatActivity() {
         setContentView(R.layout.activity_app)
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
 
-        sharedPref = getSharedPreferences(PREF_NAME, PRIVATE_MODE)
-        sharedPref.edit().putBoolean(PREF_NAME, false).apply()
+        viewModel.setShouldExit(false)
 
         if (!checkDrawOverlayPermission()) {
-                startLockTask()
+            startLockTask()
         }
 
         findViewById<View>(R.id.finish)
@@ -41,23 +38,20 @@ class App() : AppCompatActivity() {
         super.onResume()
         Log.d(TAG, "onResume")
 
-        sharedPref = getSharedPreferences(PREF_NAME, PRIVATE_MODE)
-
-        if (sharedPref.getBoolean(PREF_NAME, true)) {
+        if (viewModel.shouldExit.value) {
             if (!checkDrawOverlayPermission()) {
                 stopLockTask()
             }
             finishAndRemoveTask()
         } else {
-            sharedPref.edit().putBoolean(PREF_NAME, true).apply()
+            viewModel.setShouldExit(true)
         }
     }
 
     override fun onRestart() {
         super.onRestart()
         Log.d(TAG, "onRestart")
-        sharedPref = getSharedPreferences(PREF_NAME, PRIVATE_MODE)
-        sharedPref.edit().putBoolean(PREF_NAME, false).apply()
+        viewModel.setShouldExit(false)
     }
 
     override fun onDestroy() {
@@ -75,26 +69,17 @@ class App() : AppCompatActivity() {
     }
 
     private fun hideSystemUI() {
-        // Enables regular immersive mode.
-        // For "lean back" mode, remove SYSTEM_UI_FLAG_IMMERSIVE.
-        // Or for "sticky immersive," replace it with SYSTEM_UI_FLAG_IMMERSIVE_STICKY
         window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                // Set the content to appear under the system bars so that the
-                // content doesn't resize when the system bars hide and show.
                 or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                 or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                 or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                // Hide the nav bar and status bar
                 or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
                 or View.SYSTEM_UI_FLAG_FULLSCREEN)
     }
 
-    // Shows the system bars by removing all the flags
-    // except for the ones that make the content appear under the system bars.
     private fun showSystemUI() {
         window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                 or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                 or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN)
     }
-
 }

--- a/app/src/main/java/de/kleini/lock/LockViewModel.kt
+++ b/app/src/main/java/de/kleini/lock/LockViewModel.kt
@@ -1,0 +1,42 @@
+package de.kleini.lock
+
+import android.app.Application
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+private val Application.dataStore: DataStore<Preferences> by preferencesDataStore(name = "lock_prefs")
+
+class LockViewModel(application: Application) : AndroidViewModel(application) {
+
+    companion object {
+        private val SHOULD_EXIT_KEY = booleanPreferencesKey("should_exit")
+    }
+
+    private val _shouldExit = MutableStateFlow(false)
+    val shouldExit: StateFlow<Boolean> = _shouldExit
+
+    init {
+        viewModelScope.launch {
+            val prefs = getApplication<Application>().dataStore.data.first()
+            _shouldExit.value = prefs[SHOULD_EXIT_KEY] ?: false
+        }
+    }
+
+    fun setShouldExit(value: Boolean) {
+        _shouldExit.value = value
+        viewModelScope.launch {
+            getApplication<Application>().dataStore.edit { prefs ->
+                prefs[SHOULD_EXIT_KEY] = value
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_app.xml
+++ b/app/src/main/res/layout/activity_app.xml
@@ -26,6 +26,7 @@ android:keepScreenOn="true">
         android:paddingEnd="10dp"
         android:paddingBottom="5dp"
         android:text="@string/finish"
+        android:contentDescription="@string/finish_description"
         android:textColor="@android:color/white" />
 <requestFocus/>
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Lock</string>
     <string name="finish">Off</string>
+    <string name="finish_description">Kiosk-Modus beenden</string>
 </resources>

--- a/app/src/test/java/de/kleini/lock/LockViewModelTest.kt
+++ b/app/src/test/java/de/kleini/lock/LockViewModelTest.kt
@@ -1,0 +1,119 @@
+package de.kleini.lock
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class LockViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var application: Application
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        application = ApplicationProvider.getApplicationContext()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial shouldExit state is false`() = runTest(testDispatcher) {
+        val viewModel = LockViewModel(application)
+        advanceUntilIdle()
+        assertFalse(viewModel.shouldExit.value)
+    }
+
+    @Test
+    fun `setShouldExit true updates state to true`() = runTest(testDispatcher) {
+        val viewModel = LockViewModel(application)
+        advanceUntilIdle()
+        viewModel.setShouldExit(true)
+        advanceUntilIdle()
+        assertTrue(viewModel.shouldExit.value)
+    }
+
+    @Test
+    fun `setShouldExit false resets state to false`() = runTest(testDispatcher) {
+        val viewModel = LockViewModel(application)
+        advanceUntilIdle()
+        viewModel.setShouldExit(true)
+        advanceUntilIdle()
+        viewModel.setShouldExit(false)
+        advanceUntilIdle()
+        assertFalse(viewModel.shouldExit.value)
+    }
+
+    // Lifecycle-Sequenz: onCreate setzt shouldExit immer auf false
+    @Test
+    fun `onCreate lifecycle pattern resets shouldExit to false`() = runTest(testDispatcher) {
+        val viewModel = LockViewModel(application)
+        advanceUntilIdle()
+        viewModel.setShouldExit(true)
+        advanceUntilIdle()
+
+        viewModel.setShouldExit(false) // simuliert App.onCreate
+        advanceUntilIdle()
+
+        assertFalse(viewModel.shouldExit.value)
+    }
+
+    // Lifecycle-Sequenz: onResume setzt shouldExit auf true (normaler Lauf)
+    @Test
+    fun `onResume normal flow sets shouldExit to true`() = runTest(testDispatcher) {
+        val viewModel = LockViewModel(application)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.shouldExit.value) // nach onCreate: false
+        viewModel.setShouldExit(true)           // simuliert onResume "else"-Zweig
+        advanceUntilIdle()
+
+        assertTrue(viewModel.shouldExit.value)
+    }
+
+    // Lifecycle-Sequenz: onResume mit shouldExit=true signalisiert Exit
+    @Test
+    fun `exit condition detected when shouldExit is true on resume`() = runTest(testDispatcher) {
+        val viewModel = LockViewModel(application)
+        advanceUntilIdle()
+
+        viewModel.setShouldExit(true)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.shouldExit.value) // onResume würde Exit auslösen
+    }
+
+    // Lifecycle-Sequenz: onRestart verhindert ungewollten Exit beim nächsten onResume
+    @Test
+    fun `onRestart resets shouldExit so onResume does not trigger exit`() = runTest(testDispatcher) {
+        val viewModel = LockViewModel(application)
+        advanceUntilIdle()
+
+        viewModel.setShouldExit(true)  // normaler Zustand während Lauf
+        advanceUntilIdle()
+        viewModel.setShouldExit(false) // simuliert onRestart
+        advanceUntilIdle()
+
+        assertFalse(viewModel.shouldExit.value) // kein Exit beim nächsten onResume
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.3.72"
+    ext.kotlin_version = "2.0.21"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.1"
+        classpath "com.android.tools.build:gradle:8.7.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip


### PR DESCRIPTION
- Punkt 1: Kotlin 1.3.72 → 2.0.21, AGP 4.0.1 → 8.7.2, Gradle 6.1.1 → 8.9,
  compileSdk/targetSdk auf 35, alle Abhängigkeiten auf aktuelle Versionen,
  jcenter() durch mavenCentral() ersetzt, Java 17 Kompilierziel gesetzt,
  veraltetes kotlin-android-extensions-Plugin entfernt
- Punkt 3: Zustandslogik aus App.kt in LockViewModel (AndroidViewModel) extrahiert,
  Activity kommuniziert nur noch über ViewModel mit dem Zustand
- Punkt 4: SharedPreferences durch androidx.datastore:datastore-preferences ersetzt,
  Zustand wird asynchron persistiert und beim Start aus DataStore geladen
- Punkt 7: contentDescription für den Off-Button als String-Ressource hinzugefügt,
  alle UI-Strings vollständig über strings.xml lokalisierbar

https://claude.ai/code/session_0192E7cTTETAzzpAnTkUTpJv